### PR TITLE
Modify the timer for millisecond accuracy on newer Window versions.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -91,55 +91,39 @@ namespace {
     bool isDown = false;
     switch (wParam) {
       case WM_LBUTTONDOWN:
-      {
         isDown = true;
 
         [[fallthrough]];
-      }
       case WM_LBUTTONUP:
-      {
         keyCode = VK_LBUTTON;
         break;
-      }
       case WM_RBUTTONDOWN:
-      {
         isDown = true;
 
         [[fallthrough]];
-      }
       case WM_RBUTTONUP:
-      {
         keyCode = VK_RBUTTON;
         break;
-      }
       case WM_MBUTTONDOWN:
-      {
         isDown = true;
 
         [[fallthrough]];
-      }
       case WM_MBUTTONUP:
-      {
         keyCode = VK_MBUTTON;
         break;
-      }
       case WM_XBUTTONDOWN:
-      {
         isDown = true;
 
         [[fallthrough]];
-      }
-      case WM_XBUTTONUP:
-      {
+      case WM_XBUTTONUP: {
         auto &info = *reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
         keyCode = VK_XBUTTON1 + HIWORD(info.mouseData) - XBUTTON1;
 
         break;
       }
       case WM_MOUSEWHEEL:
-      {
         if (spamUp || spamDown) {
-          MSLLHOOKSTRUCT *info = reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
+          auto *info = reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
           bool scrollingDown = static_cast<std::make_signed_t<WORD>>(HIWORD(info->mouseData)) < 0;
 
           // If macro is active prevent manual scrolling of the opposite direction for proper freescroll emulation
@@ -147,7 +131,6 @@ namespace {
             return 1;
           }
         }
-      }
     }
 
     handleKey(keyCode, isDown);
@@ -168,31 +151,23 @@ namespace {
 
     switch (wParam) {
       case WM_KEYDOWN:
-      {
         [[fallthrough]];
-      }
       case WM_SYSKEYDOWN:
-      {
         if (info.vkCode == upKeyCode) {
           upKeyRepeatCount++;
-        }         else if (info.vkCode == downKeyCode) {
+        } else if (info.vkCode == downKeyCode) {
           downKeyRepeatCount++;
         }
         break;
-      }
       case WM_KEYUP:
-      {
         [[fallthrough]];
-      }
       case WM_SYSKEYUP:
-      {
         if (info.vkCode == upKeyCode) {
           upKeyRepeatCount = 0;
-        }         else if (info.vkCode == downKeyCode) {
+        } else if (info.vkCode == downKeyCode) {
           downKeyRepeatCount = 0;
         }
         break;
-      }
     }
 
     if (info.vkCode == upKeyCode && upKeyRepeatCount <= 1 || info.vkCode == downKeyCode && downKeyRepeatCount <= 1) {
@@ -260,16 +235,11 @@ namespace {
           case 'd':
             break;
           case 'u':
-          {
             upKeyCode = downKeyCode;
             downKeyCode = 0;
-
             break;
-          }
           default:
-          {
             throw std::runtime_error("Invalid wheel direction '+"s + wheelDirection + "+' in configuration file \"" + fileName + "\".");
-          }
         }
       }
     }

--- a/main.cpp
+++ b/main.cpp
@@ -200,10 +200,9 @@ namespace {
     return r;
   }
 
-  void CALLBACK TimerProc(void*, BOOLEAN) {
+  void CALLBACK TimerProc(UINT, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR) {
     if (isGameInFocus()) {
       auto wheelDelta = getWheelDelta();
-
       if (wheelDelta != 0) {
         mouse_event(MOUSEEVENTF_WHEEL, 0, 0, wheelDelta, 0);
       } 
@@ -407,11 +406,7 @@ void setupInputHooks() {
 
 void startTimer() {
   DWORD period = 10; // Execute every 10 milliseconds, 100 times a second.
-
-  HANDLE timer;
-  if (!CreateTimerQueueTimer(&timer, nullptr, TimerProc, nullptr, 0, period, WT_EXECUTEDEFAULT)) {
-    throw std::system_error(GetLastError(), std::system_category());
-  }
+  timeSetEvent(period, 0, TimerProc, 0, TIME_PERIODIC);
 
   while (true) {
     MSG message;
@@ -423,6 +418,8 @@ void startTimer() {
 }
 
 int main(int argc, char** argv) {
+  // Request a 1ms minimum time resolution for newer Windows versions.
+  timeBeginPeriod(1);
   try {
     LPCTSTR consoleTitle = "DOOM Eternal Freescroll Macro";
     SetConsoleTitle(consoleTitle);
@@ -438,7 +435,7 @@ int main(int argc, char** argv) {
   } catch (std::exception& e) {
     std::fprintf(stderr, "Error: %s\n\n", e.what());    
     waitForUserToExit();
-
-    return 1;
   }
+  timeEndPeriod(1);
+  return 1;
 }


### PR DESCRIPTION
Newer Windows versions use a time resolution of roughly 16ms. This means we can only reach 64 ticks per second with the macro in its current state.

In order to set the time resolution, we use timeBeginPeriod. CreateTimerQueueTimer did not respect the set resolution, so we switch to timeSetEvent instead.