### PR TITLE
Cleanup to macro. Removes need for window to be open. Add thread-safety.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,8 +19,8 @@ namespace {
   DWORD downKeyCode = 0;
   DWORD upKeyCode = 0;
 
-  volatile bool spamUp = false;
-  volatile bool spamDown = false;
+  std::atomic<bool> spamUp = false;
+  std::atomic<bool> spamDown = false;
 
   int upKeyRepeatCount = 0;
   int downKeyRepeatCount = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@
 using namespace std::literals;
 
 namespace {
-  std::string DOOM_ETERNAL_WINDOW_NAME = "DOOMEternal";
+  const std::string DOOM_ETERNAL_WINDOW_NAME = "DOOMEternal";
 
   HHOOK mouseHook;
   HHOOK keyboardHook;


### PR DESCRIPTION
* Changes to IsGameInFocus to check for the window title suffix matching DOOMEternal.
* Remove any module/process checking. No longer needed or used.
* spamUp/spamDown -> std::atomic for thread-safety.
* Various cleanup.